### PR TITLE
Add hotkeys that select the next and previous enemies

### DIFF
--- a/src/components/game/operations/Combat.vue
+++ b/src/components/game/operations/Combat.vue
@@ -910,44 +910,34 @@ export default window.OperationCombat = {
       });
     },
 
-    targetNextEnemy() {
-      const currentTarget = this.operation.context.currentTarget.toString();
-      const creatureIds = Object.keys(this.displayedCreatures);
-      let currentIndex = creatureIds.indexOf(currentTarget);
-      if (currentIndex === -1) {
-        currentIndex = 0;
-      }
+    findNextHostile(direction) {
+      const currentTarget = this.operation.context.currentTarget;
+      const creatureIds = Object.keys(this.creatures);
+      const currentIndex = creatureIds.indexOf(`${currentTarget}`);
       for (let i = 1; i < creatureIds.length; i++) {
-        const creature = this.displayedCreatures[
-          creatureIds[(i + currentIndex) % creatureIds.length]
-        ];
-        if (creature.hostile) {
+        const indexCandidate =
+          (i * direction + currentIndex + creatureIds.length) %
+          creatureIds.length;
+        const creature = this.creatures[creatureIds[indexCandidate]];
+        if (
+          creature &&
+          creature.hostile &&
+          !creature.dead &&
+          creature.operationInfo?.combatId === this.combat.id
+        ) {
           this.targetCreature(creature.id);
           return;
         }
       }
-      ToastError("Could not find next hostile creature");
+      ToastError("No valid targets");
+    },
+
+    targetNextEnemy() {
+      return this.findNextHostile(+1);
     },
 
     targetPreviousEnemy() {
-      const currentTarget = this.operation.context.currentTarget.toString();
-      const creatureIds = Object.keys(this.displayedCreatures);
-      let currentIndex = creatureIds.indexOf(currentTarget);
-      if (currentIndex === -1) {
-        currentIndex = 0;
-      }
-      for (let i = -1; i > -creatureIds.length; i--) {
-        const creature = this.displayedCreatures[
-          creatureIds[
-            (i + currentIndex + creatureIds.length) % creatureIds.length
-          ]
-        ];
-        if (creature.hostile) {
-          this.targetCreature(creature.id);
-          return;
-        }
-      }
-      ToastError("Could not find previous hostile creature");
+      return this.findNextHostile(-1);
     },
 
     lootAll() {

--- a/src/components/game/operations/Combat.vue
+++ b/src/components/game/operations/Combat.vue
@@ -799,9 +799,9 @@ export default window.OperationCombat = {
     );
     this.keyPressHandler = ($event) => {
       const key = $event.key;
-      if (key == "<") {
+      if (key === "<") {
         this.targetPreviousEnemy();
-      } else if (key == ">") {
+      } else if (key === ">") {
         this.targetNextEnemy();
       }
     };
@@ -886,7 +886,7 @@ export default window.OperationCombat = {
 
     clickedCreature(creature) {
       if (this.targetting) {
-        this.targetCreature(creature.Id);
+        this.targetCreature(creature.id);
       } else {
         this.selectedCreatureId = creature.id;
       }

--- a/src/components/game/operations/Combat.vue
+++ b/src/components/game/operations/Combat.vue
@@ -799,10 +799,9 @@ export default window.OperationCombat = {
     );
     this.keyPressHandler = ($event) => {
       const key = $event.key;
-      if(key == "<") {
+      if (key == "<") {
         this.targetPreviousEnemy();
-      }
-      else if(key == ">") {
+      } else if (key == ">") {
         this.targetNextEnemy();
       }
     };
@@ -894,27 +893,31 @@ export default window.OperationCombat = {
     },
 
     targetCreature(creatureId) {
-        GameService.request(REQUEST_CODES.UPDATE_OPERATION, {
-          updateType: "selectTarget",
-          creatureId: creatureId,
-        }).then((result) => {
-          if (result && result.ok) {
-            this.targetting = false;
-            this.fetchCombatMovesOdds();
-          } else {
-            ToastError(result.message);
-          }
-        });
+      GameService.request(REQUEST_CODES.UPDATE_OPERATION, {
+        updateType: "selectTarget",
+        creatureId: creatureId,
+      }).then((result) => {
+        if (result && result.ok) {
+          this.targetting = false;
+          this.fetchCombatMovesOdds();
+        } else {
+          ToastError(result.message);
+        }
+      });
     },
 
     targetNextEnemy() {
-      var currentTarget = this.operation.context.currentTarget.toString();
-      var creatureIds = Object.keys(this.displayedCreatures);
-      var currentIndex = creatureIds.indexOf(currentTarget);
-      if(currentIndex == -1 ){currentIndex = 0;}
-      for(var i=1; i < creatureIds.length; i++){
-        var creature = this.displayedCreatures[creatureIds[(i+currentIndex)%creatureIds.length]];
-        if(creature.hostile){
+      const currentTarget = this.operation.context.currentTarget.toString();
+      const creatureIds = Object.keys(this.displayedCreatures);
+      let currentIndex = creatureIds.indexOf(currentTarget);
+      if (currentIndex === -1) {
+        currentIndex = 0;
+      }
+      for (let i = 1; i < creatureIds.length; i++) {
+        const creature = this.displayedCreatures[
+          creatureIds[(i + currentIndex) % creatureIds.length]
+        ];
+        if (creature.hostile) {
           this.targetCreature(creature.id);
           return;
         }
@@ -923,13 +926,19 @@ export default window.OperationCombat = {
     },
 
     targetPreviousEnemy() {
-      var currentTarget = this.operation.context.currentTarget.toString();
-      var creatureIds = Object.keys(this.displayedCreatures);
-      var currentIndex = creatureIds.indexOf(currentTarget);
-      if(currentIndex == -1 ){currentIndex = 0;}
-      for(var i=-1; i > -creatureIds.length; i--){
-        var creature = this.displayedCreatures[creatureIds[(i+currentIndex)%creatureIds.length+creatureIds.length]];
-        if(creature.hostile){
+      const currentTarget = this.operation.context.currentTarget.toString();
+      const creatureIds = Object.keys(this.displayedCreatures);
+      let currentIndex = creatureIds.indexOf(currentTarget);
+      if (currentIndex === -1) {
+        currentIndex = 0;
+      }
+      for (let i = -1; i > -creatureIds.length; i--) {
+        const creature = this.displayedCreatures[
+          creatureIds[
+            ((i + currentIndex) % creatureIds.length) + creatureIds.length
+          ]
+        ];
+        if (creature.hostile) {
           this.targetCreature(creature.id);
           return;
         }

--- a/src/components/game/operations/Combat.vue
+++ b/src/components/game/operations/Combat.vue
@@ -935,7 +935,7 @@ export default window.OperationCombat = {
       for (let i = -1; i > -creatureIds.length; i--) {
         const creature = this.displayedCreatures[
           creatureIds[
-            ((i + currentIndex) % creatureIds.length) + creatureIds.length
+            (i + currentIndex + creatureIds.length) % creatureIds.length
           ]
         ];
         if (creature.hostile) {

--- a/src/components/game/operations/Combat.vue
+++ b/src/components/game/operations/Combat.vue
@@ -797,24 +797,28 @@ export default window.OperationCombat = {
     this.setAnimationSpeed(
       LocalStorageService.getItem("combat-animationSpeed", 1)
     );
-    this.keyPressHandler = ($event) => {
-      const key = $event.key;
-      if (key === "<") {
-        this.targetPreviousEnemy();
-      } else if (key === ">") {
-        this.targetNextEnemy();
-      }
-    };
-    document.addEventListener("keypress", this.keyPressHandler);
+    document.addEventListener("keydown", this.keyDownHandler);
   },
 
   beforeDestroy() {
     ControlsService.triggerControlEvent("notificationOffset", false);
     ControlsService.updateConsideredAP(0);
-    document.removeEventListener("keypress", this.keyPressHandler);
+    document.removeEventListener("keydown", this.keyDownHandler);
   },
 
   methods: {
+    keyDownHandler($event) {
+      const { key } = $event;
+      switch (key) {
+        case "ArrowLeft":
+          this.targetPreviousEnemy();
+          break;
+        case "ArrowRight":
+          this.targetNextEnemy();
+          break;
+      }
+    },
+
     setAnimationSpeed(speedValue) {
       this.ANIMATION_SPEED = speedValue;
       this.selectedAnimationSpeed = ANIMATION_SPEEDS.find(

--- a/src/components/game/operations/Combat.vue
+++ b/src/components/game/operations/Combat.vue
@@ -361,8 +361,8 @@
                   <HorizontalCenter>
                     <Button noPadding @click="targetting = true">
                       <div class="icon" :style="targetIconStyle" />
-                      <div class="target-hotkey-left">&lt;</div>
-                      <div class="target-hotkey-right">&gt;</div>
+                      <div class="target-hotkey left">&larr;</div>
+                      <div class="target-hotkey right">&rarr;</div>
                     </Button>
                   </HorizontalCenter>
                 </Vertical>
@@ -1680,22 +1680,19 @@ $side-position: 1rem;
   flex-direction: column;
 }
 
-.target-hotkey-left {
+.target-hotkey {
   font-size: 70%;
   position: absolute;
   top: -0.2em;
-  left: 0.1em;
   padding-top: 0.2rem;
   z-index: 3;
-}
 
-.target-hotkey-right {
-  font-size: 70%;
-  position: absolute;
-  top: -0.2em;
-  right: 0.1em;
-  padding-top: 0.2rem;
-  z-index: 3;
+  &.left {
+    left: 0.1em;
+  }
+  &.right {
+    right: 0.1em;
+  }
 }
 
 .gained-text {


### PR DESCRIPTION
Use < and > to select next and previous enemies in combat. 

Show an error if we couldn't work out the enemy to target (including if there's only one enemy). Include hints on the target button that the keys do something (should this be a tooltip?)

Assumptions:
Server will send the new targeting details and display it nicely after we tell it which enemy we want to target.
Displayed enemies doesn't include dead/fled enemies.
Displayed enemies are in some reasonable ordering (fairly sure this one doesn't hold!)